### PR TITLE
chore: make gpt-prompt customisable

### DIFF
--- a/gpt-commit.el
+++ b/gpt-commit.el
@@ -63,7 +63,7 @@
   "API endpoint for GPT chat completions.")
 
 
-(defconst gpt-commit-system-prompt-en
+(defvar gpt-commit-system-prompt-en
   "The user provides the result of running `git diff --cached`. You suggest a conventional commit message. Don't add anything else to the response. The following describes conventional commits.
 
 # Conventional Commits 1.0.0


### PR DESCRIPTION
At the minute the prompt is hard-coded and changing it requires the use of less-ideal approaches like `add-advice`.

Sometimes the prompt returns undesirable output, for example:

- commit message over 50 chars
- message sometimes prioritises vague summaries instead of more specific ones (e.g. `updates config` over `adds xyz dependency`)
- some changes may be unimportant compared to others, so the prompt output is discarded and written by hand instead
- conventional commit may not be used, or may use a customised version
- the size of the prompt trades-off against the size of the diff that can be analyzed
- no wider context of the overall repo so the best it can offer is 'what' and not 'why'

I figured that allowing customisation would be better than trying to micromanage the hard-coded one and publishing releases for every tweak. In that sense, one could have per-project prompts that describe the project/repo and not just the commit format.